### PR TITLE
Simplify repo structure (#8)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,6 @@ jobs:
         run: |
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${{ secrets.ANSIBLE_SSH_KEY }}"
-          ansible-playbook -i inventory.ini -u ansible playbook.yml
+          ansible-playbook -i hosts -u ansible site.yml
         env:
           ANSIBLE_HOST_KEY_CHECKING: False

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You will need `sshpass` installed (brew install hudochenkov/sshpass)
 python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
-ansible-playbook -i inventory.ini playbook.yml --check
+ansible-playbook site.yml --check
 ```
 
 ## Development
@@ -57,7 +57,7 @@ ansible-lint
 
 Unfortunately we cannot log in remotely as `root`, so we will need to manually bootstrap the box to get it ready for Ansible.
 
-1. Add entry for host in `inventory.ini`
+1. Add entry for host in `hosts`
 
 2. Install pre-requisite packages:
 
@@ -72,5 +72,5 @@ Unfortunately we cannot log in remotely as `root`, so we will need to manually b
 4. Run initial bootstrapping (this will take a while):
 
     ```
-    ansible-playbook -l <host> -i inventory.ini -u ansible --become-method=su --ask-pass --ask-become-pass playbook.yml
+    ansible-playbook -u ansible --become-method=su --ask-pass --ask-become-pass site.yml
     ```

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory = hosts
+interpreter_python = auto

--- a/hosts
+++ b/hosts
@@ -1,0 +1,1 @@
+vpsib9kvzy.sdcc.sh

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,5 +1,0 @@
-[servers]
-vpsib9kvzy ansible_host=vpsib9kvzy.sdcc.sh
-
-[all:vars]
-ansible_python_interpreter=/usr/local/bin/python3

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: servers
+- hosts: all
   tasks:
     - name: Configure sudoers rules
       copy:


### PR DESCRIPTION
Closes #8 

Follows Ansible example layout to simplify repo structure and be more in-line with best-practices.

- Add `ansible.cfg` for sensible Ansible-specific defaults
- Remove groups (there's only one host)