### PR TITLE
Create basic www jail for nginx

### DIFF
--- a/files/etc/rc.conf
+++ b/files/etc/rc.conf
@@ -1,0 +1,12 @@
+# TODO: Template this
+hostname="vpsib9kvzy.sdcc.sh"
+ifconfig_vtnet0="inet 185.112.146.129 netmask 0xffffff00"
+defaultrouter="185.112.146.1"
+
+clear_tmp_enable="YES"
+syslogd_flags="-ss"
+sendmail_enable="YES"
+sshd_enable="YES"
+dumpdev="AUTO"
+zfs_enable="YES"
+jail_enable="YES"

--- a/files/usr/jail/www/etc/rc.conf
+++ b/files/usr/jail/www/etc/rc.conf
@@ -1,0 +1,1 @@
+nginx_enable="YES"

--- a/files/usr/jail/www/usr/local/etc/nginx/nginx.conf
+++ b/files/usr/jail/www/usr/local/etc/nginx/nginx.conf
@@ -1,0 +1,35 @@
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    # TODO: Re-enable once we can mask IPs (#14)
+    access_log      off;
+    error_log       off;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        listen       80;
+        server_name  sdcc.sh;
+
+        location / {
+            root   /usr/local/www/sdcc.sh;
+            index  index.html;
+        }
+
+    }
+
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 ansible==2.10.3
-ansible-base==2.10.3
+ansible-base @ git+https://github.com/mikeanthonywild/ansible.git@10c5eea7e3fd0f0c2d58e21839d777d1be37020c
 ansible-lint==4.3.7
-cffi==1.14.3
+cffi==1.14.4
 colorama==0.4.4
 commonmark==0.9.1
 cryptography==3.2.1
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-packaging==20.4
+packaging==20.5
 pycparser==2.20
 Pygments==2.7.2
 pyparsing==2.4.7

--- a/site.yml
+++ b/site.yml
@@ -60,9 +60,133 @@
         state: present
       become: yes
 
+    - name: Configure rc.d
+      copy:
+        src: etc/rc.conf
+        dest: /etc/rc.conf
+        owner: root
+        group: wheel
+        mode: 0644
+        # TODO: Add rc.conf validation
+        #validate:
+      become: yes
+      notify: Reload services
+
+    - name: Create /usr/jail/www
+      file:
+        path: /usr/jail/www
+        owner: root
+        group: wheel
+        mode: 0755
+        state: directory
+      become: yes
+
+    - name: Install gtar (needed for unarchive)
+      package:
+        name: gtar
+        state: present
+      become: yes
+
+    # TODO: This is insanely slow - debug disk IO
+    - name: Download FreeBSD dist for www jail
+      unarchive:
+        src: ftp://ftp.freebsd.org/pub/FreeBSD/releases/amd64/{{ ansible_kernel }}/base.txz
+        dest: /usr/jail/www
+        remote_src: yes
+      become: yes
+
+    - name: Configure jails
+      template:
+        src: etc/jail.conf
+        dest: /etc/jail.conf
+        owner: root
+        group: wheel
+        mode: 0644
+      become: yes
+      notify: Restart jails
+
+    # TODO: This doesn't seem to work reliably (#13)
+    - name: Start jails
+      service:
+        name: jail
+        state: started
+      become: yes
+
+    - name: Install nginx in www jail
+      package:
+        name: nginx
+        jail: www
+        state: present
+      become: yes
+
+    - name: Configure rc.d (www jail)
+      copy:
+        src: usr/jail/www/etc/rc.conf
+        dest: /usr/jail/www/etc/rc.conf
+        owner: root
+        group: wheel
+        mode: 0644
+      become: yes
+      notify: Reload nginx
+
+    - name: Start nginx
+      service:
+        name: nginx
+        options: -j www
+        state: started
+      become: yes
+
+    - name: Create /usr/jail/www/usr/local/www/sdcc.sh
+      file:
+        path: /usr/jail/www/usr/local/www/sdcc.sh
+        owner: root
+        group: wheel
+        mode: 0755
+        state: directory
+      become: yes
+
+    - name: Create index.html
+      copy:
+        content: Hello, world!
+        dest: /usr/jail/www/usr/local/www/sdcc.sh/index.html
+        owner: root
+        group: wheel
+        mode: 0644
+      become: yes
+
+    - name: Configure nginx
+      copy:
+        src: usr/jail/www/usr/local/etc/nginx/nginx.conf
+        dest: /usr/jail/www/usr/local/etc/nginx/nginx.conf
+        owner: root
+        group: wheel
+        mode: 0644
+        # TODO: Figure out how to validate files inside the jail (#15)
+        #validate: /usr/sbin/jexec www /usr/local/sbin/nginx -t -c %s
+      become: yes
+      notify: Reload nginx
+
   handlers:
+    - name: Reload services
+      command: service -R
+      become: yes
+
     - name: Reload SSH
       service:
         name: sshd
+        state: reloaded
+      become: yes
+
+    # TODO: This doesn't seem to work reliably (#13)
+    - name: Restart jails
+      service:
+        name: jail
+        state: restarted
+      become: yes
+
+    - name: Reload nginx
+      service:
+        name: nginx
+        options: -j www
         state: reloaded
       become: yes

--- a/templates/etc/jail.conf
+++ b/templates/etc/jail.conf
@@ -1,0 +1,12 @@
+# Common config
+host.hostname = "$name.{{ ansible_hostname }}";
+# TODO: Figure out how to avoid using host networking
+ip4 = inherit;
+mount.devfs;
+exec.clean;
+path = "/usr/jail/$name";
+exec.start = "/bin/sh /etc/rc";
+exec.stop = "/bin/sh /etc/rc.shutdown";
+
+# Jails
+www {}


### PR DESCRIPTION
Closes #16 

Add tasks to setup nginx to run in a jail and serve a static HTML page.

* Requires custopatch to Ansible to add `option` parameter to `service` module — used for specifying jail to manipulate.