### PR TITLE
Configure NGINX with self-signed SSL cert

### DIFF
--- a/files/usr/local/etc/nginx/nginx.conf
+++ b/files/usr/local/etc/nginx/nginx.conf
@@ -21,8 +21,26 @@ http {
 
     #gzip  on;
 
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    ssl_certificate     /usr/local/etc/ssl/certs/www.sdcc.sh.crt;
+    ssl_certificate_key /usr/local/etc/ssl/private/www.sdcc.sh.key;
+
     server {
-        listen       80;
+        listen 80 default_server;
+        server_name _;
+
+        # Discourage deep links by using a permanent redirect to home page of HTTPS site
+        return 301 https://$host;
+    }
+
+    server {
+        server_name sdcc.sh;
+        return 301 $scheme://www.$host$request_uri;
+    }
+
+    server {
+        listen       443 ssl;
         server_name  www.sdcc.sh;
 
         location / {
@@ -32,7 +50,7 @@ http {
     }
 
     server {
-        listen       80;
+        listen       443 ssl;
         server_name  subsonic.sdcc.sh;
 
         location / {


### PR DESCRIPTION


Configure NGINX to use self-signed SSL cert. All non-HTTPS traffic is redirected (301) to HTTPS root to avoid deep-linking.