### PR TITLE
Add MOTD file and list of services

### DIFF
--- a/files/etc/motd
+++ b/files/etc/motd
@@ -1,0 +1,11 @@
+ ___  ____    ___  ___
+/ __)(  _ \  / __)/ __)
+\__ \ )(_) )( (__( (__ 
+(___/(____/  \___)\___)
+
+Welcome to sdcc.sh. There are two rules:
+
+1. Be nice.
+2. Don't get anyone arrested.
+
+Not sure where to start? Check out https://www.sdcc.sh/services.txt.

--- a/site.yml
+++ b/site.yml
@@ -27,6 +27,15 @@
       become: yes
       notify: Restart SSH
 
+    - name: Configure motd
+      copy:
+        src: etc/motd
+        dest: /etc/motd
+        owner: root
+        group: wheel
+        mode: 0644
+      become: yes
+
     - name: Create /srv directory
       file:
         path: /srv
@@ -104,8 +113,21 @@
 
     - name: Create index.html
       copy:
-        content: Hello, world!
+        content: Hello, world! <a href="https://www.sdcc.sh/services.txt">Available services</a>.
         dest: /usr/local/www/www.sdcc.sh/index.html
+        owner: root
+        group: wheel
+        mode: 0644
+      become: yes
+
+    - name: Create services.txt
+      copy:
+        content: |
+          # SERVICE     PORT/PROTOCOL URL                         DESCRIPTION
+          ssh           22/tcp        # ssh://sdcc.sh             SSH Remote Login Protocol
+          www           443/tcp       # https://www.sdcc.sh       This website
+          subsonic      443/tcp       # https://subsonic.sdcc.sh  Subsonic-compatible Music streaming server
+        dest: /usr/local/www/www.sdcc.sh/services.txt
         owner: root
         group: wheel
         mode: 0644


### PR DESCRIPTION
Closes #38

Populates `/etc/motd` with a simple welcome message listing rules and link to services listing.

Currently `services.txt` is populated directly from the Ansible task, but the intention is to have a separate repo for the website.