### PR TITLE
Fix rc.conf hostname to be FQDN

### DIFF
--- a/templates/etc/rc.conf
+++ b/templates/etc/rc.conf
@@ -1,4 +1,4 @@
-hostname="{{ ansible_hostname }}"
+hostname="{{ inventory_hostname }}"
 # TODO: Pull this config out into host vars
 ifconfig_igb0="inet 51.158.144.240 netmask 0xffffff00"
 defaultrouter="51.158.144.1"


### PR DESCRIPTION
Fixes  #42

Previously used incorrect Ansible var to populate hostname, which resulted in non-FQDN being used.

* Change `ansible_hostname` to `inventory_hostname` in `/etc/rc.conf` template to get the FQDN.