### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+CODEOWNERS  @mikeanthonywild
+.github/*   @mikeanthonywild


### PR DESCRIPTION
Closes #46

Add a GitHub CODEOWNDERS file to protect key CI pipeline code.

* Ensures only admins can approve changes to CI code to prevent secrets leakage.