### PR TITLE
Specify prod environment for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - master
 jobs:
   deploy:
+    environment: prod
     runs-on: ubuntu-latest
     name: Deploy latest changes to servers
     steps:


### PR DESCRIPTION
Fixes #48

Explicitly specify prod environment inside deploy workflow to ensure we can access secrets.