### PR TITLE
Fix race condition in Ansible rtorrent task

### DIFF
--- a/files/usr/local/etc/rtorrent/rtorrent.rc
+++ b/files/usr/local/etc/rtorrent/rtorrent.rc
@@ -118,6 +118,6 @@ schedule2 = watch_start, 10, 10, ((load.start_verbose, (cat, (cfg.watch), "start
 print = (cat, "Logging to ", (cfg.logfile))
 log.open_file = "log", (cfg.logfile)
 log.add_output = "info", "log"
-log.add_output = "tracker_debug", "log"
+#log.add_output = "tracker_debug", "log"
 
 ### END of rtorrent.rc ###

--- a/site.yml
+++ b/site.yml
@@ -208,12 +208,6 @@
         mode: 0755
       become: yes
 
-    - name: Start rtorrent
-      service:
-        name: rtorrent
-        state: started
-      become: yes
-
     - name: Create torrents-rw user group
       group:
         name: torrents-rw
@@ -247,6 +241,12 @@
         group: rtorrent
         mode: 0775
         state: directory
+      become: yes
+
+    - name: Start rtorrent
+      service:
+        name: rtorrent
+        state: started
       become: yes
 
     - name: Create /srv/bittorrent directory


### PR DESCRIPTION
Fixes #51 

Remove race condition where we would try starting rtorrent before we had created the pre-requisite runtime directories.