### PR TITLE
Update Nginx config to use Let's Encrypt cert

### DIFF
--- a/files/usr/local/etc/nginx/nginx.conf
+++ b/files/usr/local/etc/nginx/nginx.conf
@@ -23,8 +23,8 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
-    ssl_certificate     /usr/local/etc/ssl/certs/www.sdcc.dev.crt;
-    ssl_certificate_key /usr/local/etc/ssl/private/www.sdcc.dev.key;
+    ssl_certificate     /usr/local/etc/letsencrypt/live/www.sdcc.dev/fullchain.pem;
+    ssl_certificate_key /usr/local/etc/letsencrypt/live/www.sdcc.dev/privkey.pem;
 
     server {
         listen 80 default_server;


### PR DESCRIPTION
Closes #63

Point nginx at cert from Let's Encrypt instead of self-signed cert.